### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,14 @@ setup(
     author_email="griffinchure@gmail.com",
     packages=find_packages(
         exclude=('docs', 'doc', 'sandbox', 'dev', 'hplc.egg-info')),
-    include_package_data=True
+    include_package_data=True,
+    install_requires=[
+        "matplotlib>=3.7.0",
+        "numpy>=1.24.4",
+        "pandas>=2.0.3",
+        "scipy>=1.10.0",
+        "seaborn>=0.12.2",
+        "termcolor>=2.3.0",
+        "tqdm>=4.64.1",
+    ],
 )


### PR DESCRIPTION
To make sure all depend all dependencies are installed when using `pip install...`.

To test this against future changes, the line `pip install -r requirements.txt` could be removed from the github workflow.