### PR TITLE
Fix `map_peaks` aborting on the first unmapped compound

### DIFF
--- a/hplc/quant.py
+++ b/hplc/quant.py
@@ -1056,7 +1056,7 @@ check if the subtraction is acceptable!
 
             if np.sum(peak_id) == 0:
                 unmapped[k] = v["retention_time"]
-                break
+                continue
             peak_id = peak_df.peak_id.values[np.argmax(peak_id)]
             peak_df.loc[peak_df["peak_id"] == peak_id, "compound"] = k
             mapper[peak_id] = k

--- a/tests/test_chromatogram.py
+++ b/tests/test_chromatogram.py
@@ -304,6 +304,34 @@ def test_map_peaks():
         peaks = chrom.map_peaks(params)
 
 
+def test_map_peaks_missing_compound_not_last():
+    """
+    Regression test for GitHub issue #23: a compound with no matching peak must
+    not abort mapping of the remaining (present) compounds. Previously the loop
+    `break`ed on the first unmapped compound, so any compound listed after it was
+    silently skipped, and a leading miss raised "No peaks could be properly
+    mapped!" even though every other peak was present.
+    """
+    data = pd.read_csv('./tests/test_data/test_assessment_chrom.csv')
+    chrom = hplc.quant.Chromatogram(data, cols={'time': 'x', 'signal': 'y'})
+    peaks = chrom.fit_peaks()
+
+    # Build a params dict whose FIRST entry has no matching peak, followed by the
+    # real, present peaks. Insertion order is preserved by Python dicts.
+    params = {'absent': {'retention_time': peaks['retention_time'].min() - 5}}
+    for g, d in peaks.groupby('peak_id'):
+        params[f'compound_{g}'] = {'retention_time': d['retention_time'].values[0]}
+
+    with pytest.warns():
+        mapped = chrom.map_peaks(params)
+
+    # All present compounds are mapped despite the leading miss.
+    assert len(mapped) == len(peaks)
+    assert sorted(mapped['compound'].values) == [
+        f'compound_{g}' for g in peaks['peak_id'].values]
+    assert 'absent' not in mapped['compound'].values
+
+
 def test_many_peaks():
     """
     Ensures that a warning is raised if there are 10 or more peaks in a given window. 

--- a/tests/test_chromatogram.py
+++ b/tests/test_chromatogram.py
@@ -322,13 +322,13 @@ def test_map_peaks_missing_compound_not_last():
     for g, d in peaks.groupby('peak_id'):
         params[f'compound_{g}'] = {'retention_time': d['retention_time'].values[0]}
 
-    with pytest.warns():
+    with pytest.warns(match='No peak found for absent'):
         mapped = chrom.map_peaks(params)
 
     # All present compounds are mapped despite the leading miss.
     assert len(mapped) == len(peaks)
-    assert sorted(mapped['compound'].values) == [
-        f'compound_{g}' for g in peaks['peak_id'].values]
+    assert set(mapped['compound'].values) == {
+        f'compound_{g}' for g in peaks['peak_id'].values}
     assert 'absent' not in mapped['compound'].values
 
 


### PR DESCRIPTION
## Summary
This PR addresses #23. `Chromatogram.map_peaks()` stopped mapping as soon as it hit a requested compound with no peak within `loc_tolerance`. Because the loop used `break`, every compound listed *after* the missing one was silently skipped — and if the *first* compound was the missing one, `mapper` stayed empty and the method raised `ValueError("No peaks could be properly mapped!")` even when all the other compounds were present in the chromatogram.

This was reported in #23 with a reproducing example.

## Root cause
In `map_peaks` (`hplc/quant.py`), the "no peak found" branch exited the whole loop:

```python
if np.sum(peak_id) == 0:
    unmapped[k] = v["retention_time"]
    break          # <-- skips every remaining compound
```

## Fix
Change `break` to `continue` so each present compound is mapped and each absent compound still records an entry in `unmapped` and emits its warning.

## Tests
- Adds a regression test where a missing compound **precedes** valid ones and asserts the valid compounds are still mapped. (Fails on `main`, passes here.)
- Full suite green.

## Risk
Minimal — single-token logic change endorsed by the reporter and maintainer in #23. Existing `test_map_peaks` continues to pass (its missing-compound case is last in the dict, so it was unaffected by the original bug).