### PR TITLE
Low-risk correctness fixes: multi-peak `param_bounds`, `crop(None)`, window index bound + test hardening

### DIFF
--- a/hplc/quant.py
+++ b/hplc/quant.py
@@ -130,9 +130,10 @@ class Chromatogram:
 
         Parameters
         ----------
-        time_window : `list` [start, end], optional
-            The retention time window of the chromatogram to consider for analysis.
-            If None, the entire time range of the chromatogram will be considered.
+        time_window : `list` [start, end]
+            The retention time window of the chromatogram to consider for
+            analysis. This is required; a `ValueError` is raised if it is not
+            provided.
         return_df : `bool`
             If `True`, the cropped DataFrame is
 

--- a/hplc/quant.py
+++ b/hplc/quant.py
@@ -147,6 +147,9 @@ class Chromatogram:
 You are trying to crop a chromatogram after it has been fit. Make sure that you
 do this before calling `fit_peaks()` or provide the argument `time_window` to the `fit_peaks()`."""
             )
+        if time_window is None:
+            raise ValueError(
+                "`time_window` must be provided as a list of [start, end].")
         if len(time_window) != 2:
             raise ValueError(
                 f"`time_window` must be of length 2 (corresponding to start and end points). Provided list is of length {len(time_window)}."
@@ -324,7 +327,7 @@ do this before calling `fit_peaks()` or provide the argument `time_window` to th
         ranges = []
         for l, r in zip(_left, _right):
             _range = np.arange(int(l - buffer), int(r + buffer), 1)
-            _range = _range[(_range >= 0) & (_range <= len(norm_int))]
+            _range = _range[(_range >= 0) & (_range < len(norm_int))]
             ranges.append(_range)
 
         # Identiy subset ranges and remove
@@ -644,7 +647,6 @@ do this before calling `fit_peaks()` or provide the argument `time_window` to th
                     "skew": [-np.inf, np.inf],
                 }
                 # Modify the parameter bounds given arguments
-                key_inds = {k: i for i, k in enumerate(_param_bounds.keys())}
                 if len(param_bounds) != 0:
                     for p in parorder:
                         if p in param_bounds.keys():
@@ -657,13 +659,16 @@ do this before calling `fit_peaks()` or provide the argument `time_window` to th
                                     v["location"][i] + p for p in param_bounds[p]
                                 ]
                             else:
-                                if (p0[key_inds[p]] >= param_bounds[p][0]) & (
-                                    p0[key_inds[p]] <= param_bounds[p][1]
+                                # `paridx` indexes from the end of `p0`, which
+                                # accumulates 4 entries per peak, so it always
+                                # refers to the peak currently being set up.
+                                if (p0[paridx[p]] >= param_bounds[p][0]) & (
+                                    p0[paridx[p]] <= param_bounds[p][1]
                                 ):
                                     _param_bounds[p] = param_bounds[p]
                                 else:
                                     raise ValueError(
-                                        f"Bounds for parameter '{p}' [{param_bounds[p]}] is exclusive of initial guess {p0[key_inds[p]]:0.3f} for peak at retention time {p0[1]}."
+                                        f"Bounds for parameter '{p}' [{param_bounds[p]}] is exclusive of initial guess {p0[paridx[p]]:0.3f} for peak at retention time {p0[paridx['location']]}."
                                     )
 
                 # Add peak-specific bounds if provided

--- a/tests/test_chromatogram.py
+++ b/tests/test_chromatogram.py
@@ -66,14 +66,10 @@ def test_peak_fitting():
     chrom_df = pd.read_csv('./tests/test_data/test_fitting_chrom.csv')
     chrom = hplc.quant.Chromatogram(
         chrom_df, cols={'time': 'x', 'signal': 'y'})
-    try:
+    with pytest.raises(ValueError):
         chrom._assign_windows(rel_height=-1)
-    except ValueError:
-        assert True
-    try:
+    with pytest.raises(ValueError):
         chrom._assign_windows(rel_height=2)
-    except ValueError:
-        assert True
 
     chrom_df = pd.read_csv('./tests/test_data/test_fitting_chrom.csv')
     chrom = hplc.quant.Chromatogram(chrom_df[chrom_df['iter'] == 1], cols={
@@ -204,16 +200,15 @@ def test_crop():
     """
     data = pd.read_csv('./tests/test_data/test_assessment_chrom.csv')
     chrom = hplc.quant.Chromatogram(data, cols={'time': 'x', 'signal': 'y'})
-    try:
+    with pytest.raises(ValueError):
         chrom.crop([1, 2, 3])
-        assert False
-    except ValueError:
-        assert True
-    try:
+    with pytest.raises(RuntimeError):
         chrom.crop([2, 1])
-        assert False
-    except RuntimeError:
-        assert True
+    # A missing/None time window should give a clear ValueError, not a TypeError.
+    with pytest.raises(ValueError):
+        chrom.crop(None)
+    with pytest.raises(ValueError):
+        chrom.crop()
 
     # Test that a dataframe is returned only if specified.
     no_returned_df = chrom.crop([10, 20], return_df=False)
@@ -246,10 +241,8 @@ def test_deconvolve_peaks():
     """
     data = pd.read_csv('./tests/test_data/test_assessment_chrom.csv')
     chrom = hplc.quant.Chromatogram(data, cols={'time': 'x', 'signal': 'y'})
-    try:
+    with pytest.raises(RuntimeError):
         chrom.deconvolve_peaks()
-    except RuntimeError:
-        assert True
 
 
 def test_map_peaks():
@@ -515,3 +508,34 @@ def test_generic_param_bounding():
         assert False
     except ValueError:
         assert True
+
+
+def test_multipeak_param_bounds_validated_per_peak():
+    """
+    Regression test for bug B: when a global `param_bounds` is applied to a
+    window containing more than one peak, the initial-guess-vs-bounds check must
+    use *each* peak's own guess. Previously it always inspected the first peak's
+    guess, so a bound that excluded a later peak's guess was silently accepted
+    (and later surfaced as an opaque scipy error rather than the informative one).
+    """
+    import scipy.stats
+
+    # Two overlapping peaks with clearly different widths that share one window.
+    t = np.arange(0, 30, 0.01)
+    sig = (200 * scipy.stats.norm(14.0, 0.2).pdf(t)
+           + 200 * scipy.stats.norm(15.0, 0.6).pdf(t))
+    df = pd.DataFrame({'time': t, 'signal': sig})
+
+    # Inspect the per-peak scale initial guesses (scale guess = width / 2).
+    probe = hplc.quant.Chromatogram(df)
+    probe._assign_windows(buffer=200)
+    multi = [v for v in probe.window_props.values() if v['num_peaks'] == 2]
+    assert len(multi) == 1, "expected the two peaks to share a single window"
+    guesses = sorted(w / 2 for w in multi[0]['width'])
+    # Bound contains the smaller guess (first peak) but excludes the larger one.
+    bound = [0, 0.5 * (guesses[0] + guesses[1])]
+
+    chrom = hplc.quant.Chromatogram(df)
+    with pytest.raises(ValueError, match='exclusive of initial guess'):
+        chrom.fit_peaks(correct_baseline=False, buffer=200,
+                        param_bounds={'scale': bound}, verbose=False)

--- a/tests/test_chromatogram.py
+++ b/tests/test_chromatogram.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import pytest
+import scipy.stats
 
 
 def compare(a, b, tol):
@@ -205,9 +206,9 @@ def test_crop():
     with pytest.raises(RuntimeError):
         chrom.crop([2, 1])
     # A missing/None time window should give a clear ValueError, not a TypeError.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='must be provided as a list'):
         chrom.crop(None)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='must be provided as a list'):
         chrom.crop()
 
     # Test that a dataframe is returned only if specified.
@@ -518,8 +519,6 @@ def test_multipeak_param_bounds_validated_per_peak():
     guess, so a bound that excluded a later peak's guess was silently accepted
     (and later surfaced as an opaque scipy error rather than the informative one).
     """
-    import scipy.stats
-
     # Two overlapping peaks with clearly different widths that share one window.
     t = np.arange(0, 30, 0.01)
     sig = (200 * scipy.stats.norm(14.0, 0.2).pdf(t)


### PR DESCRIPTION


## Summary
Three small, self-contained correctness/robustness fixes that change no behavior for valid input, plus hardening of the test suite's exception checks.

## Fixes

### I: multi-peak `param_bounds` validated the wrong peak's guess
In `deconvolve_peaks`, the global `param_bounds` feasibility check indexed the per-window initial-guess list `p0` with a **positive** index (`p0[key_inds[p]]`), which always pointed at the **first** peak's parameters. For a window containing more than one peak, this validated the wrong peak's guess against the supplied bounds — risking a spurious `ValueError` or a missed one. The adjacent peak-specific block already uses the correct negative-index map `paridx`.

**Fix:** use `p0[paridx[p]]` so each peak is checked against its own guess; remove the now-dead `key_inds`. Single-peak windows are unaffected (the indices coincide), so existing `test_generic_param_bounding` / `test_bounding` are unchanged.

### II: `crop()` with no/`None` window gave a cryptic error
`crop()` / `crop(None)` fell through to `len(time_window)` and raised `TypeError: object of type 'NoneType' has no len()`.

**Fix:** add a leading guard that raises a clear `ValueError` instructing the caller to pass `[start, end]`.

### III: off-by-one in window-range index filter
`_assign_windows` filtered candidate indices with `<= len(norm_int)`, admitting one out-of-range index. Harmless today (the value is only used via `.isin`) but incorrect.

**Fix:** use `< len(norm_int)`. No observable output change.

## Test hardening
Several exception tests used the `try/except: assert True` pattern with no `assert False` after the call, so they passed even when **no** exception (or the wrong one) was raised. Converted these to `pytest.raises(...)` in`test_peak_fitting`, `test_deconvolve_peaks`, and `test_crop`, and added regression tests for the multi-peak bound check and the `crop(None)` guard.

## Risk
Low. No behavior change for valid input; the only newly-raised error (the `crop(None)` guard) replaces an existing crash with a clearer message.