### PR TITLE
Vectorize SNIP baseline-correction inner loop (132x-361x speedup)

### DIFF
--- a/hplc/quant.py
+++ b/hplc/quant.py
@@ -1028,11 +1028,19 @@ check if the subtraction is acceptable!
             self._bg_correction_progress_state = 0
             iter = range(1, n_iter + 1)
 
+        n_points = len(tform)
         for i in iter:
+            # Matches the original `for j in range(i, n_points - i)` loop,
+            # including its implicit no-op when that range is empty
+            # (i.e. 2*i >= n_points) -- negative-stop slicing below would
+            # otherwise silently wrap and corrupt the result in that case.
+            if 2 * i >= n_points:
+                continue
             tform_new = tform.copy()
-            for j in range(i, len(tform) - i):
-                tform_new[j] = min(
-                    tform[j], 0.5 * (tform[j + i] + tform[j - i]))
+            tform_new[i:n_points - i] = np.minimum(
+                tform[i:n_points - i],
+                0.5 * (tform[2 * i:n_points] + tform[0:n_points - 2 * i]),
+            )
             tform = tform_new
 
         # Perform the inverse of the LLS transformation and subtract


### PR DESCRIPTION
Fixes #29.

## What

`correct_baseline`'s SNIP filter had a scalar Python `min()` call inside a nested loop (`~n_iter * n_points` calls -- 2.24M for a 3,000-point chromatogram). Each outer iteration only reads the *previous* iteration's array (the `tform`/`tform_new` swap), so there's no sequential dependency within an iteration and it vectorizes directly with `np.minimum` over shifted slices.

```python
# before
for i in iter:
    tform_new = tform.copy()
    for j in range(i, len(tform) - i):
        tform_new[j] = min(tform[j], 0.5 * (tform[j + i] + tform[j - i]))
    tform = tform_new

# after
n_points = len(tform)
for i in iter:
    if 2 * i >= n_points:
        continue
    tform_new = tform.copy()
    tform_new[i:n_points - i] = np.minimum(
        tform[i:n_points - i],
        0.5 * (tform[2 * i:n_points] + tform[0:n_points - 2 * i]),
    )
    tform = tform_new
```

The `2 * i >= n_points` guard matches the original loop's implicit no-op when `range(i, n_points - i)` is empty -- without it, negative-stop slicing (`tform[0:n_points - 2*i]` when `n_points - 2*i < 0`) silently wraps to a wrong non-empty slice instead of the intended empty one. Caught this by testing against the default `window` on short synthetic signals, not just the values I originally picked.

## Correctness

Verified bit-for-bit identical output (`np.array_equal`) against the original implementation across array lengths from 10 to 10,000 (even and odd), including the `2*i >= n_points` edge case, before touching this repo's code.

All 23 existing tests pass unchanged with the patch applied, including `test_bg_estimation`, which checks corrected background against a reference dataset (`test_SNIP_chrom.csv`) to within 1.5% tolerance.

## Performance

`correct_baseline(verbose=False)`, default `window`, same call signature before/after:

| points | before | after | speedup |
|---|---|---|---|
| 3,000 | 1,122 ms | 8.5 ms | 132x |
| 36,000 | 126,890 ms | 351 ms | 361x |

## Scope

This doesn't change the SNIP algorithm or its output -- same math, vectorized instead of looped. #12 proposes eventually replacing SNIP with `pybaselines`, which I think is the right long-term call and a bigger scope than this PR; this is meant as a small, low-risk interim fix so `correct_baseline` is usable at realistic chromatogram sizes in the meantime, not a competing approach.